### PR TITLE
Add method to query cl slims

### DIFF
--- a/pandasaurus_cxg/anndata_enricher.py
+++ b/pandasaurus_cxg/anndata_enricher.py
@@ -64,7 +64,7 @@ class AnndataEnricher:
         Returns:
            The enriched results as a pandas DataFrame.
         """
-        self.is_invalid_slim_list(slim_list)
+        self.validate_slim_list(slim_list)
         self.enriched_df = self.__enricher.minimal_slim_enrichment(slim_list)
         return self.enriched_df
 
@@ -77,7 +77,7 @@ class AnndataEnricher:
         Returns:
             The enriched results as a pandas DataFrame.
         """
-        self.is_invalid_slim_list(slim_list)
+        self.validate_slim_list(slim_list)
         self.enriched_df = self.__enricher.full_slim_enrichment(slim_list)
         return self.enriched_df
 
@@ -116,7 +116,7 @@ class AnndataEnricher:
         """
         self.__enricher = Query(self.__seed_list, property_list)
 
-    def is_invalid_slim_list(self, slim_list):
+    def validate_slim_list(self, slim_list):
         """Check if any slim term in the given list is invalid.
 
         Args:

--- a/pandasaurus_cxg/anndata_loader.py
+++ b/pandasaurus_cxg/anndata_loader.py
@@ -16,8 +16,8 @@ class AnndataLoader:
             The loaded anndata object if successful, else None.
 
         Note:
-            - The method uses warnings to temporarily ignore ImplicitModificationWarning raised by anndata.
-            - If an error occurs while loading the file, an error message is printed, and None is returned.
+            - The method uses warnings to temporarily ignore ImplicitModificationWarning.
+            - If an error occurs, an error message is printed, and None is returned.
         """
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=anndata.ImplicitModificationWarning)

--- a/pandasaurus_cxg/utils/exceptions.py
+++ b/pandasaurus_cxg/utils/exceptions.py
@@ -4,8 +4,7 @@ from typing import List
 class InvalidSlimName(Exception):
     def __init__(self, invalid_slim_list: List[str], valid_slim_list: list[dict[str, str]]):
         self.message = (
-            f"The following slim names are invalid: "
-            f"{', '.join([slim for slim in invalid_slim_list])}. "
+            f"The following slim names are invalid: {', '.join(invalid_slim_list)}. "
             f"Please use slims from: "
             f"{', '.join([slim.get('name') for slim in valid_slim_list])}."
         )

--- a/pandasaurus_cxg/utils/exceptions.py
+++ b/pandasaurus_cxg/utils/exceptions.py
@@ -1,0 +1,12 @@
+from typing import List
+
+
+class InvalidSlimName(Exception):
+    def __init__(self, invalid_slim_list: List[str], valid_slim_list: list[dict[str, str]]):
+        self.message = (
+            f"The following slim names are invalid: "
+            f"{', '.join([slim for slim in invalid_slim_list])}. "
+            f"Please use slims from: "
+            f"{', '.join([slim.get('name') for slim in valid_slim_list])}."
+        )
+        super().__init__(self.message)

--- a/poetry.lock
+++ b/poetry.lock
@@ -16,6 +16,30 @@ dev = ["pdbpp (>=0.10,<1.0)", "pytest (>=6.2,<7.0)", "pytest-cov (>=3.0,<4.0)", 
 parse = ["beautifulsoup4 (>=4.10,<5.0)", "requests (>=2.12,<3)"]
 
 [[package]]
+name = "anndata"
+version = "0.9.1"
+description = "Annotated data."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "anndata-0.9.1-py3-none-any.whl", hash = "sha256:6666a39f9d6c4645a70115f38c17ccc2e2ffd9c0d08a1636c395253d73de26f1"},
+    {file = "anndata-0.9.1.tar.gz", hash = "sha256:1f28f2c427e67b0b99bdd2b281717c92a12660dfd23e0694939b6e733f0eb2c4"},
+]
+
+[package.dependencies]
+h5py = ">=3"
+natsort = "*"
+numpy = ">=1.16.5"
+packaging = ">=20"
+pandas = ">=1.1.1"
+scipy = ">1.4"
+
+[package.extras]
+dev = ["black (>=20.8b1)", "docutils", "setuptools_scm"]
+doc = ["IPython", "awkward (>=2.0.7)", "myst_parser", "nbsphinx", "scanpydoc (>=0.7.7)", "sphinx (>=4.4)", "sphinx-autodoc-typehints (>=1.11.0)", "sphinx-rtd-theme (>=1.1.1)", "sphinx_issues", "sphinxext.opengraph", "zarr"]
+test = ["awkward (>=2.0.6)", "boltons", "dask[array]", "joblib", "loompy (>=3.0.5)", "matplotlib", "openpyxl", "pytest (>=6.0)", "pytest-cov (>=2.10)", "pytest_memray", "scanpy", "scikit-learn", "zarr"]
+
+[[package]]
 name = "antlr4-python3-runtime"
 version = "4.9.3"
 description = "ANTLR 4.9.3 runtime for Python 3.7"
@@ -727,6 +751,43 @@ files = [
 [package.extras]
 docs = ["Sphinx", "docutils (<0.18)"]
 test = ["faulthandler", "objgraph", "psutil"]
+
+[[package]]
+name = "h5py"
+version = "3.8.0"
+description = "Read and write HDF5 files from Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "h5py-3.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:533d7dad466ddb7e3b30af274b630eb7c1a6e4ddf01d1c373a0334dc2152110a"},
+    {file = "h5py-3.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c873ba9fd4fa875ad62ce0e4891725e257a8fe7f5abdbc17e51a5d54819be55c"},
+    {file = "h5py-3.8.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:98a240cd4c1bfd568aaa52ec42d263131a2582dab82d74d3d42a0d954cac12be"},
+    {file = "h5py-3.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3389b63222b1c7a158bb7fe69d11ca00066740ec5574596d47a2fe5317f563a"},
+    {file = "h5py-3.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:7f3350fc0a8407d668b13247861c2acd23f7f5fe7d060a3ad9b0820f5fcbcae0"},
+    {file = "h5py-3.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:db03e3f2c716205fbdabb34d0848459840585225eb97b4f08998c743821ca323"},
+    {file = "h5py-3.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:36761693efbe53df179627a775476dcbc37727d6e920958277a7efbc18f1fb73"},
+    {file = "h5py-3.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4a506fc223def428f4329e7e1f9fe1c8c593eab226e7c0942c8d75308ad49950"},
+    {file = "h5py-3.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33b15aae79e9147aebe1d0e54099cbcde8d65e3e227cd5b59e49b1272aa0e09d"},
+    {file = "h5py-3.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:9f6f6ffadd6bfa9b2c5b334805eb4b19ca0a5620433659d8f7fb86692c40a359"},
+    {file = "h5py-3.8.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8f55d9c6c84d7d09c79fb85979e97b81ec6071cc776a97eb6b96f8f6ec767323"},
+    {file = "h5py-3.8.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b685453e538b2b5934c58a644ac3f3b3d0cec1a01b6fb26d57388e9f9b674ad0"},
+    {file = "h5py-3.8.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:377865821fe80ad984d003723d6f8890bd54ceeb5981b43c0313b9df95411b30"},
+    {file = "h5py-3.8.0-cp37-cp37m-win_amd64.whl", hash = "sha256:0fef76e10b9216657fa37e7edff6d8be0709b25bd5066474c229b56cf0098df9"},
+    {file = "h5py-3.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:26ffc344ec9984d2cd3ca0265007299a8bac8d85c1ad48f4639d8d3aed2af171"},
+    {file = "h5py-3.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:bacaa1c16810dd2b3e4417f8e730971b7c4d53d234de61fe4a918db78e80e1e4"},
+    {file = "h5py-3.8.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bae730580ae928de409d63cbe4fdca4c82c3ad2bed30511d19d34e995d63c77e"},
+    {file = "h5py-3.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f47f757d1b76f0ecb8aa0508ec8d1b390df67a8b67ee2515dc1b046f3a1596ea"},
+    {file = "h5py-3.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:f891b17e3a3e974e93f9e34e7cca9f530806543571ce078998676a555837d91d"},
+    {file = "h5py-3.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:290e00fa2de74a10688d1bac98d5a9cdd43f14f58e562c580b5b3dfbd358ecae"},
+    {file = "h5py-3.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:03890b1c123d024fb0239a3279737d5432498c1901c354f8b10d8221d1d16235"},
+    {file = "h5py-3.8.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7865de06779b14d98068da387333ad9bf2756b5b579cc887fac169bc08f87c3"},
+    {file = "h5py-3.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49bc857635f935fa30e92e61ac1e87496df8f260a6945a3235e43a9890426866"},
+    {file = "h5py-3.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:5fd2252d1fc364ba0e93dd0b7089f4906b66805cb4e6aca7fa8874ac08649647"},
+    {file = "h5py-3.8.0.tar.gz", hash = "sha256:6fead82f0c4000cf38d53f9c030780d81bfa0220218aee13b90b7701c937d95f"},
+]
+
+[package.dependencies]
+numpy = ">=1.14.5"
 
 [[package]]
 name = "hbreader"
@@ -1498,6 +1559,21 @@ files = [
     {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
     {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
 ]
+
+[[package]]
+name = "natsort"
+version = "8.3.1"
+description = "Simple yet flexible natural sorting in Python."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "natsort-8.3.1-py3-none-any.whl", hash = "sha256:d583bc9050dd10538de36297c960b93f873f0cd01671a3c50df5bd86dd391dcb"},
+    {file = "natsort-8.3.1.tar.gz", hash = "sha256:517595492dde570a4fd6b6a76f644440c1ba51e2338c8a671d7f0475fda8f9fd"},
+]
+
+[package.extras]
+fast = ["fastnumbers (>=2.0.0)"]
+icu = ["PyICU (>=1.0.0)"]
 
 [[package]]
 name = "ndex2"
@@ -3224,4 +3300,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "6eab2b532436f3bd0986f25ff5fb2a318980600c18127930db4d30eb88bdcf83"
+content-hash = "cefb11122a57f16b6ad614390db5a0efd6b0d5d06ff2b86e97b7010b7408f9e8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ packages = [{include = "pandasaurus_cxg"}]
 python = "^3.9"
 pandas = "^2.0.2"
 pandasaurus = "0.1.0"
+anndata = "^0.9.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.1"


### PR DESCRIPTION
I've added `slim_list` attribute to keep track of slim lists. It is initialised with a list of ontology names, the default value is `["Cell Ontology"]`. I've also added added a custom exception class for invalid slim names. `minimal_slim_enrichment` and `full_slim_enrichment` raises that exception in case they are called with invalid slim names.
I've added missing anndata dependency.