### PR TITLE
Skip graph clusters without author fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,4 @@ dmypy.json
 .DS_Store
 .idea/
 .DS_Store
+.vscode/

--- a/pandasaurus_cxg/graph_generator/graph_generator.py
+++ b/pandasaurus_cxg/graph_generator/graph_generator.py
@@ -189,6 +189,13 @@ class GraphGenerator:
         self.graph.add((cell_set_class, RDF.type, OWL.Class))
         self.graph.add((cell_set_class, RDFS.label, Literal(CLUSTER.get("label"))))
         for _uuid, inner_dict in grouped_dict_uuid.items():
+            if not self._get_cluster_author_fields(inner_dict):
+                logger.warning(
+                    "Skipping cluster %s because no author fields were found: %s",
+                    _uuid,
+                    inner_dict,
+                )
+                continue
             author_label_column, author_synonym_columns = self._get_cluster_author_provenance(
                 inner_dict
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pandasaurus-cxg"
-version = "0.2.6"
+version = "0.2.7"
 description = "Ontology enrichment tool for CxG standard AnnData files."
 authors = ["Ugur Bayindir <ugur@ebi.ac.uk>"]
 license = "http://www.apache.org/licenses/LICENSE-2.0"


### PR DESCRIPTION
This change prevents RDF graph generation from failing when a cluster has no author-provided label fields. Instead of raising an error, the generator now skips those clusters and logs a warning for traceability.