### PR TITLE
Add dataset metadata support to GraphGenerator

### DIFF
--- a/pandasaurus_cxg/graph_generator/graph_generator.py
+++ b/pandasaurus_cxg/graph_generator/graph_generator.py
@@ -63,6 +63,7 @@ class GraphGenerator:
         self,
         enrichment_analyzer: AnndataEnrichmentAnalyzer,
         keys: Optional[List[str]] = None,
+        dataset_metadata: Optional[Dict[str, str]] = None,
     ):
         """
         Initializes GraphGenerator instance.
@@ -72,6 +73,8 @@ class GraphGenerator:
             keys (Optional[List[str]]): List of column names to select from the DataFrame to
                 generate the report. Defaults to None.
                 Please refrain from using this parameter until the next notification
+            dataset_metadata (Optional[Dict[str, str]]): Optional CELLxGENE dataset metadata.
+                Supported keys are `dataset_id` and `dataset_version_id`.
 
         """
         # TODO need to think about how to handle the requirement of enrichment and co_annotation_analysis methods
@@ -89,6 +92,7 @@ class GraphGenerator:
         self.ns = Namespace("http://example.org/")
         self.graph = Graph()
         self.label_priority = None
+        self.dataset_metadata = dataset_metadata
         # TODO This part needs a better approach in the future
         self.graph.bind("ns", self.ns)
         self.graph.bind("obo", Namespace("http://purl.obolibrary.org/obo/"))
@@ -108,15 +112,31 @@ class GraphGenerator:
         citation_dict = {}
         uns = self.ea.enricher_manager.anndata.uns
         census_dataset_id = None
-        if citation_field_name in uns.keys():
+        dataset_seed_id = None
+        if self.dataset_metadata is not None:
+            dataset_id = self.dataset_metadata.get("dataset_id")
+            dataset_version_id = self.dataset_metadata.get("dataset_version_id")
+            if citation_field_name in uns.keys():
+                citation_dict = parse_citation_field_into_dict(uns[citation_field_name])
+            if dataset_id:
+                census_dataset_id = dataset_id
+                dataset_seed_id = dataset_id
+                dataset_class = URIRef(get_cxg_dataset_url(dataset_id))
+            elif dataset_version_id:
+                dataset_seed_id = dataset_version_id
+                dataset_class = URIRef(get_cxg_dataset_url(dataset_version_id))
+            else:
+                dataset_seed_id = str(uuid.uuid4())
+                dataset_class = URIRef(self.ns[dataset_seed_id])
+        elif citation_field_name in uns.keys():
             citation_dict = parse_citation_field_into_dict(uns[citation_field_name])
             census_dataset_id = extract_dataset_version_id(citation_dict.get("download_link"))
-            cxg_versioned_dataset_id = census_dataset_id or str(uuid.uuid4())
-            dataset_class = URIRef(get_cxg_dataset_url(cxg_versioned_dataset_id))
+            dataset_seed_id = census_dataset_id or str(uuid.uuid4())
+            dataset_class = URIRef(get_cxg_dataset_url(dataset_seed_id))
         else:
             # if citation_field_name doesn't exist we use random uuid as cxg_versioned_dataset_id
-            cxg_versioned_dataset_id = str(uuid.uuid4())
-            dataset_class = URIRef(self.ns[cxg_versioned_dataset_id])
+            dataset_seed_id = str(uuid.uuid4())
+            dataset_class = URIRef(self.ns[dataset_seed_id])
         self.graph.add((dataset_class, RDF.type, URIRef(DATASET.get("iri"))))
         self.graph.add((dataset_class, RDFS.label, Literal(DATASET.get("label"))))
         for key, value in uns.items():
@@ -135,6 +155,15 @@ class GraphGenerator:
             self.graph.add(
                 (dataset_class, URIRef(self.ns[ncname_safe(key)]), Literal(value))
             )
+        if self.dataset_metadata is not None:
+            dataset_id = self.dataset_metadata.get("dataset_id")
+            dataset_version_id = self.dataset_metadata.get("dataset_version_id")
+            if dataset_id:
+                self.graph.add((dataset_class, self.ns.dataset_id, Literal(dataset_id)))
+            if dataset_version_id:
+                self.graph.add(
+                    (dataset_class, self.ns.dataset_version_id, Literal(dataset_version_id))
+                )
         if census_dataset_id:
             self.graph.add((dataset_class, self.ns.census_dataset_id, Literal(census_dataset_id)))
         self.graph.add(
@@ -181,7 +210,7 @@ class GraphGenerator:
 
             if temp_dict not in grouped_dict_uuid.values():
                 grouped_dict_uuid[
-                    str(uuid.uuid5(uuid.UUID(cxg_versioned_dataset_id), str(temp_dict)))
+                    str(uuid.uuid5(uuid.UUID(dataset_seed_id), str(temp_dict)))
                 ] = temp_dict
 
         # generate a resource for each free-text cell_type annotation and cell_type_ontology_term annotation

--- a/poetry.lock
+++ b/poetry.lock
@@ -5596,29 +5596,16 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.2"
-description = "Backported and Experimental Type Hints for Python 3.8+"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-markers = "python_version >= \"3.11\""
-files = [
-    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
-    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
-]
-
-[[package]]
-name = "typing-extensions"
 version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
-markers = "python_version == \"3.10\""
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
+markers = {dev = "python_version == \"3.10\""}
 
 [[package]]
 name = "tzdata"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pandasaurus-cxg"
-version = "0.2.7"
+version = "0.2.8"
 description = "Ontology enrichment tool for CxG standard AnnData files."
 authors = ["Ugur Bayindir <ugur@ebi.ac.uk>"]
 license = "http://www.apache.org/licenses/LICENSE-2.0"

--- a/test/graph_generator/test_graph_generator.py
+++ b/test/graph_generator/test_graph_generator.py
@@ -16,6 +16,12 @@ from pandasaurus_cxg.utils.exceptions import (
 )
 
 
+SCHEMA_TEST_DATASET_VERSION_ID = "75c059c8-8fb7-4e6e-a618-a3e01ac42060"
+SCHEMA_TEST_DATASET_ID = "11111111-2222-3333-4444-555555555555"
+SCHEMA_TEST_LEGACY_CLUSTER_ID = "b2f21d75-2dd5-57c9-a4dc-92c9818926fb"
+SCHEMA_TEST_METADATA_CLUSTER_ID = "0883d0c4-3eee-5abc-9c36-8e3d0c7d183e"
+
+
 @pytest.fixture(autouse=True)
 def mock_census_version(monkeypatch):
     monkeypatch.setattr(
@@ -66,10 +72,9 @@ def graph_generator_instance_for_kidney(enrichment_analyzer_instance_for_kidney_
 
 @pytest.fixture()
 def graph_generator_instance_for_schema_unit_test():
-    dataset_uuid = "75c059c8-8fb7-4e6e-a618-a3e01ac42060"
     citation = (
         "Publication: https://doi.org/10.1038/s41586-021-03569-1 "
-        f"Version: https://datasets.cellxgene.cziscience.com/{dataset_uuid}.h5ad "
+        f"Version: https://datasets.cellxgene.cziscience.com/{SCHEMA_TEST_DATASET_VERSION_ID}.h5ad "
         "Collection: lung_atlas"
     )
     report_df = pd.DataFrame(
@@ -123,6 +128,72 @@ def graph_generator_instance_for_schema_unit_test():
         ),
     )
     return GraphGenerator(ea)
+
+
+@pytest.fixture()
+def graph_generator_instance_for_schema_unit_test_with_metadata():
+    citation = (
+        "Publication: https://doi.org/10.1038/s41586-021-03569-1 "
+        f"Version: https://datasets.cellxgene.cziscience.com/{SCHEMA_TEST_DATASET_VERSION_ID}.h5ad "
+        "Collection: lung_atlas"
+    )
+    report_df = pd.DataFrame(
+        [
+            [
+                "subclass.full",
+                "Monocyte-derived macrophages",
+                "cluster_matches",
+                "author_cell_type",
+                "Monocyte-derived macrophages",
+                5,
+                5,
+            ],
+            [
+                "subclass.full",
+                "Monocyte-derived macrophages",
+                "cluster_matches",
+                "subclass.l1",
+                "macrophage",
+                5,
+                5,
+            ],
+            [
+                "subclass.full",
+                "Monocyte-derived macrophages",
+                "cluster_matches",
+                "cell_type",
+                "macrophage",
+                5,
+                5,
+            ],
+        ],
+        columns=[
+            "field_name1",
+            "value1",
+            "predicate",
+            "field_name2",
+            "value2",
+            "field_name1_cell_count",
+            "field_name2_cell_count",
+        ],
+    )
+    ea = SimpleNamespace(
+        analyzer_manager=SimpleNamespace(
+            report_df=report_df,
+            all_cell_type_identifiers=["subclass.full", "subclass.l1", "author_cell_type", "cell_type"],
+        ),
+        enricher_manager=SimpleNamespace(
+            anndata=SimpleNamespace(uns={"citation": citation}),
+            seed_dict={},
+        ),
+    )
+    return GraphGenerator(
+        ea,
+        dataset_metadata={
+            "dataset_id": SCHEMA_TEST_DATASET_ID,
+            "dataset_version_id": SCHEMA_TEST_DATASET_VERSION_ID,
+        },
+    )
 
 
 @pytest.fixture()
@@ -257,6 +328,22 @@ def test_graph_generator_init_with_valid_input(enrichment_analyzer_instance_for_
     assert graph_generator.ns == Namespace("http://example.org/")
     assert graph_generator.graph is not None
     assert graph_generator.label_priority is None
+
+
+def test_graph_generator_init_accepts_dataset_metadata(
+    enrichment_analyzer_instance_for_immune_data,
+):
+    ea = enrichment_analyzer_instance_for_immune_data
+    ea.enricher_manager.simple_enrichment()
+    ea.co_annotation_report()
+
+    dataset_metadata = {
+        "dataset_id": SCHEMA_TEST_DATASET_ID,
+        "dataset_version_id": SCHEMA_TEST_DATASET_VERSION_ID,
+    }
+    graph_generator = GraphGenerator(ea, dataset_metadata=dataset_metadata)
+
+    assert graph_generator.dataset_metadata == dataset_metadata
 
 
 def test_generate_rdf_graph_with_merge(graph_generator_instance_for_kidney, expected_stable_ids):
@@ -568,10 +655,76 @@ def test_generate_rdf_graph_adds_dataset_census_properties(
     assert (
         dataset_node,
         graph_generator.ns.census_dataset_id,
-        Literal("75c059c8-8fb7-4e6e-a618-a3e01ac42060"),
+        Literal(SCHEMA_TEST_DATASET_VERSION_ID),
     ) in graph_generator.graph
     assert (
         dataset_node,
         graph_generator.ns.census_version_cached,
         Literal("2025-11-08"),
     ) in graph_generator.graph
+    assert (dataset_node, graph_generator.ns.dataset_id, None) not in graph_generator.graph
+    assert (dataset_node, graph_generator.ns.dataset_version_id, None) not in graph_generator.graph
+
+
+def test_generate_rdf_graph_uses_dataset_metadata_for_dataset_properties(
+    graph_generator_instance_for_schema_unit_test_with_metadata,
+):
+    graph_generator = graph_generator_instance_for_schema_unit_test_with_metadata
+    graph_generator.generate_rdf_graph(merge=True)
+
+    dataset_node = next(
+        graph_generator.graph.subjects(
+            predicate=RDF.type, object=URIRef("https://schema.org/Dataset")
+        )
+    )
+    assert dataset_node == URIRef(
+        f"https://cellxgene.cziscience.com/e/{SCHEMA_TEST_DATASET_ID}.cxg/"
+    )
+    assert (
+        dataset_node,
+        graph_generator.ns.dataset_id,
+        Literal(SCHEMA_TEST_DATASET_ID),
+    ) in graph_generator.graph
+    assert (
+        dataset_node,
+        graph_generator.ns.dataset_version_id,
+        Literal(SCHEMA_TEST_DATASET_VERSION_ID),
+    ) in graph_generator.graph
+    assert (
+        dataset_node,
+        graph_generator.ns.census_dataset_id,
+        Literal(SCHEMA_TEST_DATASET_ID),
+    ) in graph_generator.graph
+    assert (
+        dataset_node,
+        graph_generator.ns.census_version_cached,
+        Literal("2025-11-08"),
+    ) in graph_generator.graph
+
+
+def test_generate_rdf_graph_prefers_dataset_id_for_uuid_seeding(
+    graph_generator_instance_for_schema_unit_test_with_metadata,
+):
+    graph_generator = graph_generator_instance_for_schema_unit_test_with_metadata
+    graph_generator.generate_rdf_graph(merge=True)
+
+    cluster_nodes = list(
+        graph_generator.graph.subjects(
+            predicate=RDF.type, object=URIRef("http://purl.obolibrary.org/obo/PCL_0010001")
+        )
+    )
+    assert cluster_nodes == [URIRef(f"http://example.org/{SCHEMA_TEST_METADATA_CLUSTER_ID}")]
+
+
+def test_generate_rdf_graph_preserves_legacy_uuid_seeding_without_dataset_metadata(
+    graph_generator_instance_for_schema_unit_test,
+):
+    graph_generator = graph_generator_instance_for_schema_unit_test
+    graph_generator.generate_rdf_graph(merge=True)
+
+    cluster_nodes = list(
+        graph_generator.graph.subjects(
+            predicate=RDF.type, object=URIRef("http://purl.obolibrary.org/obo/PCL_0010001")
+        )
+    )
+    assert cluster_nodes == [URIRef(f"http://example.org/{SCHEMA_TEST_LEGACY_CLUSTER_ID}")]


### PR DESCRIPTION
This PR adds optional dataset_metadata support to GraphGenerator, using stable CELLxGENE dataset_id for dataset provenance and UUID seeding while preserving legacy behavior when metadata is absent.